### PR TITLE
[8.0.r1] Android.mk: Remove setting LOCAL_MULTILIB from AUDIOSERVER_MULTILIB

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -21,7 +21,6 @@ LOCAL_MODULE               := sound_trigger.primary.$(TARGET_BOARD_PLATFORM)
 LOCAL_MODULE_TAGS          := optional
 LOCAL_MODULE_OWNER         := qti
 LOCAL_MODULE_RELATIVE_PATH := hw
-LOCAL_MULTILIB             := $(AUDIOSERVER_MULTILIB)
 LOCAL_VENDOR_MODULE        := true
 
 LOCAL_CFLAGS += -Wall -Werror


### PR DESCRIPTION
AOSP has abandoned this flag.
https://android.googlesource.com/platform/frameworks/av/+/00c50ac8dca4113921822dce1511e6e153197d34%5E%21/#F0